### PR TITLE
feat: create course function and test

### DIFF
--- a/src/auralex.cairo
+++ b/src/auralex.cairo
@@ -1,1 +1,61 @@
-pub mod auralex;
+#[starknet::contract]
+pub mod Auralex {
+    use auralex_contracts::base::types::{CourseDetails, ResourceType};
+    use auralex_contracts::interfaces::IAuralex::IAuralex;
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
+    };
+    use starknet::{ContractAddress, get_block_timestamp};
+
+    #[storage]
+    struct Storage {
+        // Course management
+        courses: Map<u256, CourseDetails>,
+        next_course_id: u256,
+    }
+
+
+    #[abi(embed_v0)]
+    impl AuralexImpl of IAuralex<ContractState> {
+        fn create_course(
+            ref self: ContractState, name: ByteArray, instructor: ContractAddress, enroll_fee: u256,
+        ) -> u256 {
+            // Get the current course ID
+            let id = self.next_course_id.read() + 1; // Use it before incrementing
+            let timestamp = get_block_timestamp();
+
+            let mut course_type = ResourceType::Paid;
+            if (enroll_fee == 0) {
+                course_type = ResourceType::Free;
+            }
+            // Create a new course struct
+            let new_course = CourseDetails {
+                course_id: id,
+                name,
+                instructor,
+                total_enrolled: 0,
+                course_type: course_type,
+                enroll_fee,
+                updated_at: timestamp,
+                created_at: timestamp,
+            };
+
+            // Store the course in the courses map
+            self.courses.write(id, new_course);
+
+            // Increment course ID and update storage **after** using it
+            self.next_course_id.write(id);
+
+            id
+        }
+
+
+        fn get_course(self: @ContractState, course_id: u256) -> CourseDetails {
+            // Retrieve and return the course
+            let course = self.courses.read(course_id);
+
+            course
+        }
+    }
+}

--- a/src/base/types.cairo
+++ b/src/base/types.cairo
@@ -10,6 +10,8 @@ pub struct CourseDetails {
     pub total_enrolled: u256,
     pub course_type: ResourceType,
     pub enroll_fee: u256,
+    pub updated_at: u64,
+    pub created_at: u64,
 }
 
 #[derive(Drop, Serde, starknet::Store, Clone)]

--- a/src/interfaces/IAuralex.cairo
+++ b/src/interfaces/IAuralex.cairo
@@ -1,10 +1,14 @@
 use starknet::ContractAddress;
-
+use crate::base::types::CourseDetails;
 #[starknet::interface]
 pub trait IAuralex<TContractState> {
     // Courses
-    fn create_course(ref self: TContractState, course_details: ByteArray) -> u256;
-    fn enroll_for_course(ref self: TContractState, course_id: u256, fee: u256);
-    fn mint_course_certificate(ref self: TContractState, course_id: u256);
-    fn verify_course_credential(self: @TContractState, course_id: u256, student: ContractAddress);
+    fn create_course(
+        ref self: TContractState, name: ByteArray, instructor: ContractAddress, enroll_fee: u256,
+    ) -> u256;
+    fn get_course(self: @TContractState, course_id: u256) -> CourseDetails;
+    // fn enroll_for_course(ref self: TContractState, course_id: u256, fee: u256);
+// fn mint_course_certificate(ref self: TContractState, course_id: u256);
+// fn verify_course_credential(self: @TContractState, course_id: u256, student:
+// ContractAddress);
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,3 +1,5 @@
 pub mod auralex;
 pub mod base;
-pub mod interfaces;
+pub mod interfaces {
+    pub mod IAuralex;
+}

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -1,1 +1,82 @@
+use auralex_contracts::base::types::{CourseDetails, ResourceType};
+use auralex_contracts::interfaces::IAuralex::{IAuralexDispatcher, IAuralexDispatcherTrait};
+use snforge_std::{CheatSpan, ContractClassTrait, DeclareResultTrait, cheat_caller_address, declare};
+use starknet::{ContractAddress, contract_address_const};
 
+
+fn setup() -> ContractAddress {
+    let declare_result = declare("Auralex");
+    assert(declare_result.is_ok(), 'Contract declaration failed');
+
+    let contract_class = declare_result.unwrap().contract_class();
+    let mut calldata = array![];
+
+    let deploy_result = contract_class.deploy(@calldata);
+    assert(deploy_result.is_ok(), 'Contract deployment failed');
+
+    let (contract_address, _) = deploy_result.unwrap();
+
+    contract_address
+}
+
+
+#[test]
+fn test_create_free_course() {
+    let contract_address = setup();
+    let dispatcher = IAuralexDispatcher { contract_address };
+
+    // Test input values
+    let user: ContractAddress = contract_address_const::<'user'>();
+    let name: ByteArray = "John";
+    let enroll_fee: u256 = 0;
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, user, CheatSpan::Indefinite);
+
+    // Call create_course
+    let course_id = dispatcher.create_course(name.clone(), user, enroll_fee);
+
+    // Validate that the course ID is correctly incremented
+    assert(course_id == 1, 'Course ID should start from 0');
+
+    // Retrieve the course to verify it was stored correctly
+    let course = dispatcher.get_course(course_id);
+
+    assert(course.name == name, 'Course title mismatch');
+    assert(course.instructor == user, 'instructor description mismatch');
+    assert(course.total_enrolled == 0, 'total enrolled mismatch');
+    assert(course.enroll_fee == 0, 'enroll fee mismatch');
+    assert(course.course_type == ResourceType::Free, 'Course type mismatch');
+    assert(course.enroll_fee == enroll_fee, 'enroll_fee mismatch');
+}
+
+#[test]
+fn test_create_paid_course() {
+    let contract_address = setup();
+    let dispatcher = IAuralexDispatcher { contract_address };
+
+    // Test input values
+    let user: ContractAddress = contract_address_const::<'user'>();
+    let name: ByteArray = "John";
+
+    let enroll_fee: u256 = 100;
+
+    // Ensure the caller is the admin
+    cheat_caller_address(contract_address, user, CheatSpan::Indefinite);
+
+    // Call create_course
+    let course_id = dispatcher.create_course(name.clone(), user, enroll_fee);
+
+    // Validate that the course ID is correctly incremented
+    assert(course_id == 1, 'Course ID should start from 0');
+
+    // Retrieve the course to verify it was stored correctly
+    let course = dispatcher.get_course(course_id);
+
+    assert(course.name == name, 'Course title mismatch');
+    assert(course.instructor == user, 'instructor description mismatch');
+    assert(course.total_enrolled == 0, 'total enrolled mismatch');
+    assert(course.enroll_fee == 100, 'enroll fee mismatch');
+    assert(course.course_type == ResourceType::Paid, 'Course type mismatch');
+    assert(course.enroll_fee == enroll_fee, 'enroll_fee mismatch');
+}


### PR DESCRIPTION
I implemented a function that enables users to create a course by providing all necessary course details such as the title, description, price, instructor address, and other relevant metadata. Once submitted, the function stores this information in a mapping that keeps track of all created courses, associating each course with a unique identifier.

Additionally, I developed a retrieval function that allows users or external contracts to access a specific course and view its full details. This function returns all stored data associated with the course, making it easy to display course information on the frontend or use it in further smart contract logic.
